### PR TITLE
本日の集計内の集計出来ない項目を非表示にする

### DIFF
--- a/src/components/TodayNumbersSection/style.scss
+++ b/src/components/TodayNumbersSection/style.scss
@@ -43,25 +43,25 @@
 
       // 上段
       .josm-today-numbers-info-item:nth-child(-n+3) {
-        border-bottom: dashed 1px var(--g-200);
-        padding-bottom: 8px;
+        // border-bottom: dashed 1px var(--g-200);
+        // padding-bottom: 8px;
       }
 
       // 下段
       .josm-today-numbers-info-item:nth-child(n+4) {
-        padding-top: 8px;
+        // padding-top: 8px;
       }
 
       // 左列
       .josm-today-numbers-info-item:nth-child(3n+1) {
         padding-left: 8px;
-        border-right: dashed 1px var(--g-200);
+        // border-right: dashed 1px var(--g-200);
       }
 
       // 中列
       .josm-today-numbers-info-item:nth-child(3n+2) {
         padding-inline: 8px;
-        border-right: dashed 1px var(--g-200);
+        // border-right: dashed 1px var(--g-200);
       }
 
       // 右列

--- a/src/pages/BaroNational/NationalPublications/index.js
+++ b/src/pages/BaroNational/NationalPublications/index.js
@@ -65,10 +65,12 @@ export default function NationalPublications() {
                   />
                 </p>
               </Col>
+              <Col n='12'>
+                <DataCardSection lang={lang} />
+              </Col>
             </Row>
           </Container>
           <Glossary entries={GlossaryEntries} />
-          <DataCardSection lang={lang} />
         </Row>
         <Row>
           <GraphNavigation mobileTitleIntl={mobileButtonLabel[lang][pathname]}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -295,13 +295,13 @@ const HomePage = () => {
                   intlSubTitle='app.publications'
                   backgroundColorClass='bg-purple-25'
                 />
-                <TodayNumbersItem
+                {/* <TodayNumbersItem
                   itemKey='journal'
                   iconName='icon-bsso-2'
                   iconColor='purple-50'
                   intlSubTitle='app.journals'
                   backgroundColorClass='bg-publication-25'
-                />
+                /> */}
                 <TodayNumbersItem
                   itemKey='publisher'
                   iconName='icon-bsso-14'
@@ -309,7 +309,7 @@ const HomePage = () => {
                   intlSubTitle='app.health-publi.publishers'
                   backgroundColorClass='bg-yellow-medium-50'
                 />
-                <TodayNumbersItem
+                {/* <TodayNumbersItem
                   itemKey='repository'
                   iconName='icon-bsso-10'
                   iconColor='green-medium-75'
@@ -322,7 +322,7 @@ const HomePage = () => {
                   iconColor='green-medium-75'
                   intlSubTitle='app.thesis'
                   backgroundColorClass='bg-purple-medium-50'
-                />
+                /> */}
                 <TodayNumbersItem
                   itemKey='obsDates'
                   iconName='icon-bsso-10'


### PR DESCRIPTION
非表示にした項目は次の通りです。

- 博士論文
- オープン・アーカイブ
- 雑誌

併せて、出版物ページの導入部が、ビューポート横幅が1920pxよりも大きい場合にカラム落ちする不具合も修正しました。